### PR TITLE
Also pass the standard file, since the CWD is not always correctly set

### DIFF
--- a/lib/atom-css-sniffer.js
+++ b/lib/atom-css-sniffer.js
@@ -50,6 +50,27 @@ function _getCommand(projectPath) {
 }
 
 /**
+ * Return the standards file to use for this project.
+ *
+ * @param {string} projectPath
+ * @return {string|null}
+ */
+function _getStandardsFile(projectPath) {
+    let file = projectPath + '/csssniff.xml.dist';
+
+    if (!filesystem.existsSync(file)) {
+        // do we have a WWW folder?
+        file = projectPath + '/www/csssniff.xml.dist';
+
+        if (!filesystem.existsSync(file)) {
+            return null;
+        }
+    }
+
+    return file;
+}
+
+/**
  * Return a promise which resolves the current API version of the sniffer.
  *
  * The returned version is either null or a string.
@@ -160,9 +181,16 @@ export default {
                     if (version === '2.0') {
                         args.push('--stdin');
 
+                        // Add the correct standards file
+                        let standard = _getStandardsFile(projectPath[0]);
+
+                        if (null !== standard) {
+                            args.push('--standard=' + standard);
+                        }
+
                         // Add the file for any matching rules
                         if (editorFile !== 'untitled') {
-                            args.push(editorPath + '/' + editorFile);
+                            args.push(editorPath);
                         }
                     }
 


### PR DESCRIPTION
Also pass the standard file, since the CWD is not always correctly set. Atom's working directory isn't always the project root...